### PR TITLE
Add question mark to screenshot URL to prevent caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Visit the [GitHub Page](https://welbornt.github.io/pencil-pusher/) to play the g
 
 ## Screenshot
 
-![Game Screenshot](screenshot.png)
+![Game Screenshot](screenshot.png?)
 
 ## Game Overview
 


### PR DESCRIPTION
Fixed issue with the cached screenshot in the readme not reflected the current screenshot. solution from https://github.com/atom/markdown-preview/issues/207#issuecomment-248848108